### PR TITLE
Use CURLFile instead of `@` syntax

### DIFF
--- a/lib/Sp_Api.php
+++ b/lib/Sp_Api.php
@@ -371,7 +371,7 @@ class Sp_Api extends Sp_Lib
 		);
 
 		$photos = array(
-			'photo' => '@' . $filepath,
+			'photo' => new CURLFile($filepath),
 		);
 
 		return $this->_makeApiRequest($params, $photos);
@@ -404,7 +404,7 @@ class Sp_Api extends Sp_Lib
         );
 
         $photos = array(
-            'photo' => '@' . $filepath,
+            'photo' => new CURLFile($filepath),
         );
 
         return $this->_makeApiRequest($params, $photos);


### PR DESCRIPTION
Fixes a deprecation error on later PHP versions.
