### PR TITLE
Adding support for Contacts API methods.

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -3,19 +3,19 @@
 // Configure your desired settings here
 $shootproof_client_id = 'YOUR_CLIENT_ID_HERE';
 $shootproof_api_scope = array(
-	'sp.studio.info',
-	'sp.event.get_list',
-	'sp.event.create',
-	'sp.event.photo_exists',
-	'sp.event.get_photos',
-	'sp.album.get_list',
-	'sp.album.create',
-	'sp.album.get_photos',
-	'sp.photo.upload',
-	'sp.photo.delete',
-	'sp.order.get_list',
-	'sp.order.get_details',
-	'sp.auth.deauthorize',
+    'sp.studio.info',
+    'sp.event.get_list',
+    'sp.event.create',
+    'sp.event.photo_exists',
+    'sp.event.get_photos',
+    'sp.album.get_list',
+    'sp.album.create',
+    'sp.album.get_photos',
+    'sp.photo.upload',
+    'sp.photo.delete',
+    'sp.order.get_list',
+    'sp.order.get_details',
+    'sp.auth.deauthorize',
 );
 
 // Include the ShootProof PHP SDK files
@@ -30,12 +30,12 @@ session_start();
 
 // Get the URL of the current page to redirect back to
 if (empty($_SESSION['redirect_url'])) {
-	$_SESSION['redirect_url'] = sprintf(
-		'%s://%s%s',
-		isset($_SERVER['HTTPS']) ? 'https' : 'http',
-		$_SERVER['HTTP_HOST'],
-		$_SERVER['REQUEST_URI']
-	);
+    $_SESSION['redirect_url'] = sprintf(
+        '%s://%s%s',
+        isset($_SERVER['HTTPS']) ? 'https' : 'http',
+        $_SERVER['HTTP_HOST'],
+        $_SERVER['REQUEST_URI']
+    );
 }
 
 // Configure the ShootProof OAuth client
@@ -43,23 +43,23 @@ $auth = new Sp_Auth($shootproof_client_id, $_SESSION['redirect_url'], implode(' 
 
 // Exchange the authorization code for an access token
 if (empty($_SESSION['sp_tokens']) && ! empty($_GET['code'])) {
-	try {
-	    $_SESSION['sp_tokens'] = $auth->requestAccessToken($_GET['code']);
-	} catch (Exception $e) {
-	    echo $e->getMessage();
-	    exit;
-	}
+    try {
+        $_SESSION['sp_tokens'] = $auth->requestAccessToken($_GET['code']);
+    } catch (Exception $e) {
+        echo $e->getMessage();
+        exit;
+    }
 }
 
 // Test the API by calling the sp.event.get_list ShootProof API method
 if ( ! empty($_SESSION['sp_tokens']['access_token'])) {
-	try {
-	    $client = new Sp_Api($_SESSION['sp_tokens']['access_token']);
-	    $events = $client->getEvents();
-	} catch (Exception $e) {
-	    echo $e->getMessage();
-	    exit;
-	}
+    try {
+        $client = new Sp_Api($_SESSION['sp_tokens']['access_token']);
+        $events = $client->getEvents();
+    } catch (Exception $e) {
+        echo $e->getMessage();
+        exit;
+    }
 }
 
 ?>
@@ -68,10 +68,10 @@ if ( ! empty($_SESSION['sp_tokens']['access_token'])) {
 
 <?php if ( ! empty($_SESSION['sp_tokens'])): ?>
 
-	<h1>Access Tokens</h1>
-	<pre><?php print_r($_SESSION['sp_tokens']) ?></pre>
+    <h1>Access Tokens</h1>
+    <pre><?php print_r($_SESSION['sp_tokens']) ?></pre>
 
-	<h1>Event Listing</h1>
-	<pre><?php print_r($events) ?></pre>
+    <h1>Event Listing</h1>
+    <pre><?php print_r($events) ?></pre>
 
 <?php endif; ?>

--- a/lib/Sp_Api.php
+++ b/lib/Sp_Api.php
@@ -671,7 +671,7 @@ class Sp_Api extends Sp_Lib
     public function bulkCreateContacts(array $contacts)
     {
         $params = array(
-            'method' => 'sp.contact.bulk_create'
+            'method' => 'sp.contact.bulk_create',
             'contacts' => $contacts
         );
 

--- a/lib/Sp_Api.php
+++ b/lib/Sp_Api.php
@@ -593,19 +593,69 @@ class Sp_Api extends Sp_Lib
      */
     public function createContact(array $contactData)
     {
-        if (!array_key_exists('first_name', $contactData) ||
-            !array_key_exists('email', $contactData)
-        ) {
-            throw new Exception(
-                'Both first_name and email values are required.'
-            );
-        }
-
         $params = array_merge(
             array(
                 'method' => 'sp.contact.create'
             ),
             $contactData
+        );
+
+        return $this->_makeApiRequest($params);
+    }
+
+    /**
+     * Method to update a new contact.
+     *
+     * Supported key-value pairs:
+     *
+     *     brand_id
+     *     first_name (required)
+     *     last_name
+     *     email (required)
+     *     phone
+     *     business_name
+     *     notes
+     *     tags (array of strings)
+     *     address (associative array, or null to remove)
+     *         address_1
+     *         address_2
+     *         city
+     *         state
+     *         state_other
+     *         country (required if address is provided)
+     *         zip_postal
+     *
+     * @param array $contactData Associative array of contact data.
+     * @return array
+     */
+    public function updateContact($contactId, array $contactData)
+    {
+        $params = array_merge(
+            array(
+                'method' => 'sp.contact.create',
+                'contact_id' => $contactId
+            ),
+            $contactData
+        );
+
+        return $this->_makeApiRequest($params);
+    }
+
+    /**
+     * Method to delete a contact.
+     *
+     * @param integer $contactId
+     * @return array
+     */
+    public function deleteContact($contactId)
+    {
+        if (is_null($contactId) || $contactId == '') {
+            throw new Exception('The contactId is required to delete a contact.');
+        }
+
+        $params = array(
+            'method' => 'sp.contact.delete',
+            'contact_id' => $contactId
         );
 
         return $this->_makeApiRequest($params);

--- a/lib/Sp_Api.php
+++ b/lib/Sp_Api.php
@@ -13,7 +13,7 @@ class Sp_Api extends Sp_Lib
      *
      * @var string
      */
-    protected $_baseEndPoint = 'https://api.bdeshong.shootproof.com/v2';
+    protected $_baseEndPoint = 'https://api.shootproof.com/v2';
 
     /**
      * Property to hold the access token to be used on all API requests

--- a/lib/Sp_Api.php
+++ b/lib/Sp_Api.php
@@ -642,6 +642,43 @@ class Sp_Api extends Sp_Lib
     }
 
     /**
+     * Method to create a multiple contacts in bulk.
+     *
+     * Must be an array of associative arrays.  The same key-value pauirs
+     * in Sp_Api::createContact() are supported in the inner associative arrays.
+     * Supported key-value pairs:
+     *
+     *     brand_id
+     *     first_name (required)
+     *     last_name
+     *     email (required)
+     *     phone
+     *     business_name
+     *     notes
+     *     tags (array of strings)
+     *     address (associative array)
+     *         address_1
+     *         address_2
+     *         city
+     *         state
+     *         state_other
+     *         country (required if address is provided)
+     *         zip_postal
+     *
+     * @param array $contactData Array of associative arrays of contact data.
+     * @return array
+     */
+    public function bulkCreateContacts(array $contacts)
+    {
+        $params = array(
+            'method' => 'sp.contact.bulk_create'
+            'contacts' => $contacts
+        );
+
+        return $this->_makeApiRequest($params);
+    }
+
+    /**
      * Method to delete a contact.
      *
      * @param integer $contactId

--- a/lib/Sp_Api.php
+++ b/lib/Sp_Api.php
@@ -13,7 +13,7 @@ class Sp_Api extends Sp_Lib
      *
      * @var string
      */
-    protected $_baseEndPoint = 'https://api.shootproof.com/v2';
+    protected $_baseEndPoint = 'https://api.bdeshong.shootproof.com/v2';
 
     /**
      * Property to hold the access token to be used on all API requests
@@ -578,7 +578,7 @@ class Sp_Api extends Sp_Lib
      *     phone
      *     business_name
      *     notes
-     *     tags (array of strings)
+     *     tags (string of tags, separated by commas)
      *     address (associative array)
      *         address_1
      *         address_2
@@ -615,7 +615,7 @@ class Sp_Api extends Sp_Lib
      *     phone
      *     business_name
      *     notes
-     *     tags (array of strings)
+     *     tags (string of tags, separated by commas)
      *     address (associative array, or null to remove)
      *         address_1
      *         address_2
@@ -655,7 +655,7 @@ class Sp_Api extends Sp_Lib
      *     phone
      *     business_name
      *     notes
-     *     tags (array of strings)
+     *     tags (string of tags, separated by commas)
      *     address (associative array)
      *         address_1
      *         address_2

--- a/lib/Sp_Api.php
+++ b/lib/Sp_Api.php
@@ -522,7 +522,7 @@ class Sp_Api extends Sp_Lib
 
     /**
      * Method to return all active brands for a studio.
-     * 
+     *
      * @return array
      */
     public function getBrands()
@@ -536,7 +536,7 @@ class Sp_Api extends Sp_Lib
 
     /**
      * Method to return data on a single brand.
-     * 
+     *
      * @param integer $brandId Brand ID to retrieve for.
      * @return array
      */
@@ -545,6 +545,67 @@ class Sp_Api extends Sp_Lib
         $params = array(
             'method' => 'sp.brand.info',
             'brand_id' => $brandId
+        );
+
+        return $this->_makeApiRequest($params);
+    }
+
+    /**
+     * Method to return data on a single contact.
+     *
+     * @param integer $contactId Contact ID to retrieve for.
+     * @return array
+     */
+    public function getContactInfo($contactId)
+    {
+        $params = array(
+            'method' => 'sp.contact.info',
+            'contact_id' => $contactId
+        );
+
+        return $this->_makeApiRequest($params);
+    }
+
+    /**
+     * Method to create a new contact.
+     *
+     * Supported key-value pairs:
+     *
+     *     brand_id
+     *     first_name (required)
+     *     last_name
+     *     email (required)
+     *     phone
+     *     business_name
+     *     notes
+     *     tags (array of strings)
+     *     address (associative array)
+     *         address_1
+     *         address_2
+     *         city
+     *         state
+     *         state_other
+     *         country (required if address is provided)
+     *         zip_postal
+     *
+     * @param array $contactData Associative array of contact data.
+     * @return array
+     */
+    public function createContact(array $contactData)
+    {
+        if (!array_key_exists('first_name', $contactData) ||
+            !array_key_exists('email', $contactData)
+        ) {
+            throw new Exception(
+                'Both first_name and email values are required.'
+            );
+        }
+
+        $params = array_merge(
+            array(
+                'method' => 'sp.contact.create'
+            ),
+            $contactData
         );
 
         return $this->_makeApiRequest($params);

--- a/lib/Sp_Auth.php
+++ b/lib/Sp_Auth.php
@@ -83,34 +83,34 @@ class Sp_Auth extends Sp_Lib
         return $this;
     }
 
-	/**
-	 * Method to get the appId
-	 *
-	 * @return string
-	 */
-	protected function _getClientId()
-	{
-		return $this->_clientId;
-	}
-
-	/**
-	 * Method to return the redirect uri
-	 *
-	 * @return string
-	 */
-	protected function _getRedirectUri()
-	{
-		return $this->_redirectUri;
+    /**
+     * Method to get the appId
+     *
+     * @return string
+     */
+    protected function _getClientId()
+    {
+        return $this->_clientId;
     }
 
-	/**
-	 * Method to return the scope
-	 *
-	 * @return string
-	 */
-	protected function _getScope()
-	{
-		return $this->_scope;
+    /**
+     * Method to return the redirect uri
+     *
+     * @return string
+     */
+    protected function _getRedirectUri()
+    {
+        return $this->_redirectUri;
+    }
+
+    /**
+     * Method to return the scope
+     *
+     * @return string
+     */
+    protected function _getScope()
+    {
+        return $this->_scope;
     }
 
     /**

--- a/lib/Sp_Exception.php
+++ b/lib/Sp_Exception.php
@@ -1,3 +1,76 @@
 <?php
 
-class Sp_Exception extends Exception {}
+/**
+ * Base ShootProof PHP SDK exception.
+ *
+ * To find more information and for documentation of the API please
+ * visit http://developer.shootproof.com
+ */
+class Sp_Exception extends Exception
+{
+    /**
+     * Response body, if set upon construction.
+     *
+     * @var string
+     */
+    protected $_responseBody;
+
+    /**
+     * Constructor.
+     *
+     * @param string $msg Exception message.
+     * @param integer $code Exception code; optional.
+     * @param string|null $responseBody Response body string; optional.
+     * @return void
+     * @see Exception::__construct()
+     */
+    public function __construct($msg, $code = 0, $responseBody = null)
+    {
+        $this->_responseBody = $responseBody;
+    }
+
+    /**
+     * Returns the raw response body, if set.
+     *
+     * @return string|null
+     */
+    public function getResponseBody()
+    {
+        return $this->_responseBody;
+    }
+
+    /**
+     * Gets the response body as an array, if the response body is JSON-encoded
+     * data.  Otherwise, returns null.
+     *
+     * @return array|null
+     */
+    public function getResponseData()
+    {
+        $data = null;
+
+        if ($body = $this->getResponseBody()) {
+            if (($decoded = json_decode($body, true))) {
+                $data = $decoded;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Override __toString() to show the response data, if available.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $string = parent::__toString();
+
+        if (($responseData = $this->getResponseData())) {
+            $string .= "\nresponse body data: " . print_r($responseData, true);
+        }
+
+        return $string;
+    }
+}

--- a/lib/Sp_Lib.php
+++ b/lib/Sp_Lib.php
@@ -120,7 +120,7 @@ class Sp_Lib
     protected function _flattenMultiDimensionalParams($arrays, array &$new = array(), $prefix = null)
     {
         if (is_object($arrays)) {
-            $arrays = get_object_vars( $arrays );
+            $arrays = get_object_vars($arrays);
         }
 
         foreach ($arrays as $key => $value) {

--- a/lib/Sp_Lib.php
+++ b/lib/Sp_Lib.php
@@ -66,7 +66,7 @@ class Sp_Lib
 		if ($error) {
 			throw new Sp_CurlException($error, $errno);
 		}
-		
+
 		if (!$response) {
 			throw new Sp_NoResponseException('The API did not return any response. Error #' . $info['http_code']);
 		}
@@ -74,7 +74,11 @@ class Sp_Lib
 		$json = json_decode($response, true);
 
 		if ($json['stat'] != 'ok') {
-			throw new Sp_Exception('The API did not return an OK response. ' . $json['msg']);
+			throw new Sp_Exception(
+                'The API did not return an OK response. ' . $json['msg'],
+                0,
+                $response
+            );
 		}
 
 		return $json;

--- a/lib/Sp_Lib.php
+++ b/lib/Sp_Lib.php
@@ -43,6 +43,14 @@ class Sp_Lib
 			$params = array_merge($params, $photos);
 		}
 
+        foreach ($params as $key => $value) {
+            if (is_array($value)) {
+                $flattened = array();
+                $params = $this->_flattenMultiDimensionalParams($params, $flattened);
+                $params = $flattened;
+            }
+        }
+
 		// send along some headers for reporting
 		$headers = array(
 			'X-WRAPPER: ' . $this->_version
@@ -100,6 +108,29 @@ class Sp_Lib
 		$url .= '?' . http_build_query($params, NULL, '&');
 		return $url;
 	}
+
+    /**
+     * Adapted from http://stackoverflow.com/a/8224117
+     *
+     * @param array $arrays Source array.
+     * @param array $new Array for modified arrays, by reference.
+     * @param string $prefix Field prefix; optional.
+     * @return void
+     */
+    protected function _flattenMultiDimensionalParams($arrays, &$new = array(), $prefix = null)
+    {
+        if (is_object($arrays)) {
+            $arrays = get_object_vars( $arrays );
+        }
+
+        foreach ($arrays as $key => $value) {
+            $k = isset( $prefix ) ? $prefix . '[' . $key . ']' : $key;
+
+            if (is_array($value) || is_object($value)) {
+                $this->_flattenMultiDimensionalParams($value, $new, $k);
+            } else {
+                $new[$k] = $value;
+            }
+        }
+    }
 }
-
-

--- a/lib/Sp_Lib.php
+++ b/lib/Sp_Lib.php
@@ -124,7 +124,10 @@ class Sp_Lib
         }
 
         foreach ($arrays as $key => $value) {
-            $k = isset( $prefix ) ? $prefix . '[' . $key . ']' : $key;
+            $k =
+                isset($prefix) ?
+                    $prefix . '[' . $key . ']' :
+                    $key;
 
             if (is_array($value) || is_object($value)) {
                 $this->_flattenMultiDimensionalParams($value, $new, $k);

--- a/lib/Sp_Lib.php
+++ b/lib/Sp_Lib.php
@@ -12,7 +12,7 @@ class Sp_Lib
      *
      * @var string
      */
-    protected $_version = 'php-1.5.0';
+    protected $_version = 'php-1.6.0';
 
     /**
      * Wrapper method to make an api request

--- a/lib/Sp_Lib.php
+++ b/lib/Sp_Lib.php
@@ -45,8 +45,7 @@ class Sp_Lib
 
         foreach ($params as $key => $value) {
             if (is_array($value)) {
-                $flattened = array();
-                $params = $this->_flattenMultiDimensionalParams($params, $flattened);
+                $flattened = $this->_flattenMultiDimensionalParams($params);
                 $params = $flattened;
             }
         }
@@ -113,12 +112,13 @@ class Sp_Lib
      * Adapted from http://stackoverflow.com/a/8224117
      *
      * @param array $arrays Source array.
-     * @param array &$new Array for modified arrays, by reference.
      * @param string $prefix Field prefix; optional.
      * @return void
      */
-    protected function _flattenMultiDimensionalParams($arrays, array &$new = array(), $prefix = null)
+    protected function _flattenMultiDimensionalParams($arrays, $prefix = null)
     {
+        $new = array();
+
         if (is_object($arrays)) {
             $arrays = get_object_vars($arrays);
         }
@@ -130,10 +130,16 @@ class Sp_Lib
                     $key;
 
             if (is_array($value) || is_object($value)) {
-                $this->_flattenMultiDimensionalParams($value, $new, $k);
+                $new =
+                    array_merge(
+                        $new,
+                        $this->_flattenMultiDimensionalParams($value, $k)
+                    );
             } else {
                 $new[$k] = $value;
             }
         }
+
+        return $new;
     }
 }

--- a/lib/Sp_Lib.php
+++ b/lib/Sp_Lib.php
@@ -7,41 +7,41 @@
  */
 class Sp_Lib
 {
-	/**
-	 * Property to hold the version of the plugin
-	 *
-	 * @var string
-	 */
-	protected $_version = 'php-1.5.0';
+    /**
+     * Property to hold the version of the plugin
+     *
+     * @var string
+     */
+    protected $_version = 'php-1.5.0';
 
-	/**
-	 * Wrapper method to make an api request
-	 *
-	 * @param $code auth code
-	 * @return json response with access/refresh token
-	 */
-	protected function _makeApiRequest($params, $photos = array())
-	{
-		$token = array('access_token' => $this->_getAccessToken());
+    /**
+     * Wrapper method to make an api request
+     *
+     * @param $code auth code
+     * @return json response with access/refresh token
+     */
+    protected function _makeApiRequest($params, $photos = array())
+    {
+        $token = array('access_token' => $this->_getAccessToken());
 
-		$params = array_merge($params, $token);
+        $params = array_merge($params, $token);
 
-		return $this->_makeRequest($this->_baseEndPoint, $params, $photos);
-	}
+        return $this->_makeRequest($this->_baseEndPoint, $params, $photos);
+    }
 
-	/**
-	 * Method to make the request to the API
-	 *
-	 * @param array $params
-	 * @param array $photos
-	 * @return array
-	 */
-	protected function _makeRequest($url, $params = array(), $photos = array())
-	{
-		// if any photos exist, let's merge them into the params
-		if (count($photos)) {
-			$params = array_merge($params, $photos);
-		}
+    /**
+     * Method to make the request to the API
+     *
+     * @param array $params
+     * @param array $photos
+     * @return array
+     */
+    protected function _makeRequest($url, $params = array(), $photos = array())
+    {
+        // if any photos exist, let's merge them into the params
+        if (count($photos)) {
+            $params = array_merge($params, $photos);
+        }
 
         foreach ($params as $key => $value) {
             if (is_array($value)) {
@@ -51,63 +51,63 @@ class Sp_Lib
             }
         }
 
-		// send along some headers for reporting
-		$headers = array(
-			'X-WRAPPER: ' . $this->_version
-		);
+        // send along some headers for reporting
+        $headers = array(
+            'X-WRAPPER: ' . $this->_version
+        );
 
-		// init curl to make the request
-		$curl = curl_init();
-		curl_setopt($curl, CURLOPT_URL, $url);
-		curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 5);
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($curl, CURLOPT_POST, true);
-		curl_setopt($curl, CURLOPT_POSTFIELDS, $params);
-		curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+        // init curl to make the request
+        $curl = curl_init();
+        curl_setopt($curl, CURLOPT_URL, $url);
+        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_POST, true);
+        curl_setopt($curl, CURLOPT_POSTFIELDS, $params);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
 
-		// the API response
-		$response = curl_exec($curl);
-		$info = curl_getinfo($curl);
-		$error = curl_error($curl);
-		$errno = curl_errno($curl);
+        // the API response
+        $response = curl_exec($curl);
+        $info = curl_getinfo($curl);
+        $error = curl_error($curl);
+        $errno = curl_errno($curl);
 
-		if ($error) {
-			throw new Sp_CurlException($error, $errno);
-		}
+        if ($error) {
+            throw new Sp_CurlException($error, $errno);
+        }
 
-		if (!$response) {
-			throw new Sp_NoResponseException('The API did not return any response. Error #' . $info['http_code']);
-		}
+        if (!$response) {
+            throw new Sp_NoResponseException('The API did not return any response. Error #' . $info['http_code']);
+        }
 
-		$json = json_decode($response, true);
+        $json = json_decode($response, true);
 
-		if ($json['stat'] != 'ok') {
-			throw new Sp_Exception(
+        if ($json['stat'] != 'ok') {
+            throw new Sp_Exception(
                 'The API did not return an OK response. ' . $json['msg'],
                 0,
                 $response
             );
-		}
+        }
 
-		return $json;
-	}
+        return $json;
+    }
 
-	/**
-	 * Build the URL for given path and parameters.
-	 *
-	 * @param $path
-	 *   (optional) The path.
-	 * @param $params
-	 *   (optional) The query parameters in associative array.
-	 *
-	 * @return
-	 *   The URL for the given parameters.
-	 */
-	protected function _getUri($path = '', $params = array()) {
-		$url = $path;
-		$url .= '?' . http_build_query($params, NULL, '&');
-		return $url;
-	}
+    /**
+     * Build the URL for given path and parameters.
+     *
+     * @param $path
+     *   (optional) The path.
+     * @param $params
+     *   (optional) The query parameters in associative array.
+     *
+     * @return
+     *   The URL for the given parameters.
+     */
+    protected function _getUri($path = '', $params = array()) {
+        $url = $path;
+        $url .= '?' . http_build_query($params, NULL, '&');
+        return $url;
+    }
 
     /**
      * Adapted from http://stackoverflow.com/a/8224117

--- a/lib/Sp_Lib.php
+++ b/lib/Sp_Lib.php
@@ -113,11 +113,11 @@ class Sp_Lib
      * Adapted from http://stackoverflow.com/a/8224117
      *
      * @param array $arrays Source array.
-     * @param array $new Array for modified arrays, by reference.
+     * @param array &$new Array for modified arrays, by reference.
      * @param string $prefix Field prefix; optional.
      * @return void
      */
-    protected function _flattenMultiDimensionalParams($arrays, &$new = array(), $prefix = null)
+    protected function _flattenMultiDimensionalParams($arrays, array &$new = array(), $prefix = null)
     {
         if (is_object($arrays)) {
             $arrays = get_object_vars( $arrays );


### PR DESCRIPTION
* Adds Contacts API method support to PHP SDK.
* Note that a private method is added in order to support flattening of a PHP multi-dimensional array into the key-value pairs expected by PHP.  cURL's setting of POST values doesn't handle multi-dimensional arrays.
* This array change should not affect any other existing methods, as none of them accept multi-dimensional arrays to begin with.  Flattening will happen automatically based on the contents of the ```$params``` array given on call to ```Sp_Lib::_makeRequest()```.