### PR TITLE
Fixup 70ad9d5e9751cf92078f17f142bcf634e5b5f90f

### DIFF
--- a/lib/Sp_Api.php
+++ b/lib/Sp_Api.php
@@ -389,7 +389,7 @@ class Sp_Api extends Sp_Lib
         );
 
         $photos = array(
-            'photo' => '@' . $filepath,
+            'photo' => new CURLFile($filepath),
         );
 
         return $this->_makeApiRequest($params, $photos);


### PR DESCRIPTION
Fixes PHP error:

```
NOTICE: E_DEPRECATED: curl_setopt(): The usage of the @filename API for file uploading is deprecated. Please use the CURLFile class instead
PHP Deprecated:  curl_setopt(): The usage of the @filename API for file uploading is deprecated. Please use the CURLFile class instead in /Users/jhill/Development/shootproof-cli/vendor/shootproof/php-sdk/lib/Sp_Lib.php on line 65
```